### PR TITLE
Formatting cleanups:

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note: The server above **must** be set for DNS validation.
 
 Another option is to just add the hook scripts along with any other options when calling Certbot like so:
 ```
-$ certbot renew -- manual-auth-hook /path/to/hook.sh -- manual-cleanup-hook /path/to/cleanup.sh
+$ certbot renew --manual-auth-hook /path/to/hook.sh --manual-cleanup-hook /path/to/cleanup.sh
 ```
 #### Note: There is a 15 minute wait for DNS propagation.
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -8,44 +8,50 @@ while [ -h "$SOURCE"  ]; do
   [[ $SOURCE != /*  ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-echo "Recieved request for" "${CERTBOT_DOMAIN}"
+echo "Received request for" "${CERTBOT_DOMAIN}"
 cd ${DIR}
 source config.sh
 
 DOMAIN=${CERTBOT_DOMAIN}
+
 ## Get current list (updating may alter rrid, etc)
 curl -s "https://www.namesilo.com/api/dnsListRecords?version=1&type=xml&key=$APIKEY&domain=$DOMAIN" > $CACHE$DOMAIN.xml
+
 ## Check for existing ACME record
 if grep -q "_acme-challenge" $CACHE$DOMAIN.xml ; then
+
 	## Get record ID
-    RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '_acme-challenge.$DOMAIN' ]" $CACHE$DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
+	RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '_acme-challenge.$DOMAIN' ]" $CACHE$DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
 	## Update DNS record in Namesilo:
 	curl -s "https://www.namesilo.com/api/dnsDeleteRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID" > $RESPONSE
 	RESPONSE_CODE=`xmllint --xpath "//namesilo/reply/code/text()"  $RESPONSE`
 	## Process response, maybe wait
+
 	case $RESPONSE_CODE in
 		300)
 			echo "ACME challenge record successfully removed"
 			;;
-	   280)
-		RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
-		echo "Record removal failed."
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
-		echo "reason: $RESPONSE_DETAIL"
+		280)
+			RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
+			echo "Record removal failed."
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
+			echo "reason: $RESPONSE_DETAIL"
 			;;
-	   *)
-		RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
-		echo "Namesilo returned code: $RESPONSE_CODE"
-		echo "Reason: $RESPONSE_DETAIL"
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
+		*)
+			RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
+			echo "Namesilo returned code: $RESPONSE_CODE"
+			echo "Reason: $RESPONSE_DETAIL"
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
 			;;
 	esac
+
 fi
+
 if [ -f $RESPONSE ] ; then
-    rm $RESPONSE
+	rm $RESPONSE
 fi
 if [ -f $CACHE$DOMAIN.xml ] ; then
-    rm $CACHE$DOMAIN.xml
+	rm $CACHE$DOMAIN.xml
 fi

--- a/hook.sh
+++ b/hook.sh
@@ -8,7 +8,7 @@ while [ -h "$SOURCE"  ]; do
   [[ $SOURCE != /*  ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE"  )" && pwd  )"
-echo "Recieved request for" "${CERTBOT_DOMAIN}"
+echo "Received request for" "${CERTBOT_DOMAIN}"
 cd ${DIR}
 source config.sh
 
@@ -17,14 +17,17 @@ VALIDATION=${CERTBOT_VALIDATION}
 
 ## Get the XML & record ID
 curl -s "https://www.namesilo.com/api/dnsListRecords?version=1&type=xml&key=$APIKEY&domain=$DOMAIN" > $CACHE$DOMAIN.xml
+
 ## Check for existing ACME record
 if grep -q "_acme-challenge" $CACHE$DOMAIN.xml
 then
+
 	## Get record ID
-    RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '_acme-challenge.$DOMAIN' ]" $CACHE$DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
+	RECORD_ID=`xmllint --xpath "//namesilo/reply/resource_record/record_id[../host/text() = '_acme-challenge.$DOMAIN' ]" $CACHE$DOMAIN.xml | grep -oP '(?<=<record_id>).*?(?=</record_id>)'`
 	## Update DNS record in Namesilo:
 	curl -s "https://www.namesilo.com/api/dnsUpdateRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrid=$RECORD_ID&rrhost=_acme-challenge&rrvalue=$VALIDATION&rrttl=3600" > $RESPONSE
 	RESPONSE_CODE=`xmllint --xpath "//namesilo/reply/code/text()"  $RESPONSE`
+
 	## Process response, maybe wait
 	case $RESPONSE_CODE in
 		300)
@@ -35,24 +38,27 @@ then
 				sleep 60s
 			done
 			;;
-	   280)
-		RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
-		echo "Update aborted, please check your NameSilo account."
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
-		echo "reason: $RESPONSE_DETAIL"
+		280)
+			RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
+			echo "Update aborted, please check your NameSilo account."
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
+			echo "reason: $RESPONSE_DETAIL"
 			;;
-	   *)
-		echo "Namesilo returned code: $RESPONSE_CODE"
-		echo "Reason: $RESPONSE_DETAIL"
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
+		*)
+			echo "Namesilo returned code: $RESPONSE_CODE"
+			echo "Reason: $RESPONSE_DETAIL"
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
 			;;
 	esac
+
 else
+
 	## Add the record
 	curl -s "https://www.namesilo.com/api/dnsAddRecord?version=1&type=xml&key=$APIKEY&domain=$DOMAIN&rrtype=TXT&rrhost=_acme-challenge&rrvalue=$VALIDATION&rrttl=3600" > $RESPONSE
 	RESPONSE_CODE=`xmllint --xpath "//namesilo/reply/code/text()"  $RESPONSE`
+
 	## Process response, maybe wait
 	case $RESPONSE_CODE in
 		300)
@@ -63,20 +69,20 @@ else
 				sleep 60s
 			done
 			;;
-	   280)
-
-		RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
-		echo "DNS addition aborted, please check your NameSilo account."
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
-		echo "reason: $RESPONSE_DETAIL"
+		280)
+			RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
+			echo "DNS addition aborted, please check your NameSilo account."
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
+			echo "reason: $RESPONSE_DETAIL"
 			;;
-	   *)
-		RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
-		echo "Namesilo returned code: $RESPONSE_CODE"
-		echo "Reason: $RESPONSE_DETAIL"
-		echo "Domain: $DOMAIN"
-		echo "rrid: $RECORD_ID"
+		*)
+			RESPONSE_DETAIL=`xmllint --xpath "//namesilo/reply/detail/text()"  $RESPONSE`
+			echo "Namesilo returned code: $RESPONSE_CODE"
+			echo "Reason: $RESPONSE_DETAIL"
+			echo "Domain: $DOMAIN"
+			echo "rrid: $RECORD_ID"
 			;;
 	esac
+
 fi


### PR DESCRIPTION
Formatting cleanups:
- README.md: fix option names (remove space after '--'; fixes #1)
- {hook,clean}.sh: tidy up formatting (thank you for using tabs! ;)); also correct spelling for 'Recieved'